### PR TITLE
Fix to keep first triplet from DRKG in DataFrame

### DIFF
--- a/embedding_analysis/Train_embeddings.ipynb
+++ b/embedding_analysis/Train_embeddings.ipynb
@@ -51,7 +51,7 @@
     "download_and_extract()\n",
     "drkg_file = '../data/drkg/drkg.tsv'\n",
     "\n",
-    "df = pd.read_csv(drkg_file, sep=\"\\t\")\n",
+    "df = pd.read_csv(drkg_file, sep=\"\\t\", header=None)\n",
     "triples = df.values.tolist()"
    ]
   },


### PR DESCRIPTION
Need to use `header=None` for `pd.read_csv()` in order to ensure that first triplet in `drkg.tsv` is not treated as header of table